### PR TITLE
misc. warning fixes

### DIFF
--- a/cinelerra/device1394output.C
+++ b/cinelerra/device1394output.C
@@ -185,6 +185,8 @@ int Device1394Output::get_dv1394()
 {
 	if(adevice) return adevice->out_config->driver == AUDIO_DV1394;
 	if(vdevice) return vdevice->out_config->driver == PLAYBACK_DV1394;
+
+	return 0;
 }
 
 int Device1394Output::open(char *path,

--- a/cinelerra/renderengine.C
+++ b/cinelerra/renderengine.C
@@ -370,6 +370,8 @@ int64_t RenderEngine::session_position()
 				edl->session->sample_rate /
 				command->get_speed() + 0.5);
 	}
+
+  return 0;
 }
 
 void RenderEngine::reset_sync_position()
@@ -393,6 +395,8 @@ int64_t RenderEngine::sync_position()
 			edl->session->sample_rate);
 		return result;
 	}
+
+  return 0;
 }
 
 PluginServer* RenderEngine::scan_plugindb(char *title, 

--- a/cinelerra/transportque.C
+++ b/cinelerra/transportque.C
@@ -148,6 +148,8 @@ float TransportCommand::get_speed()
 			return 2;
 			break;
 	}
+
+  return 0;
 }
 
 // Assume starting without pause

--- a/cinelerra/vdevicebuz.C
+++ b/cinelerra/vdevicebuz.C
@@ -450,6 +450,8 @@ int VDeviceBUZ::get_norm(int norm)
 		case PAL:           return VIDEO_MODE_PAL;       break;
 		case SECAM:         return VIDEO_MODE_SECAM;     break;
 	}
+
+  return 0;
 }
 
 int VDeviceBUZ::read_buffer(VFrame *frame)

--- a/cinelerra/videodevice.C
+++ b/cinelerra/videodevice.C
@@ -544,6 +544,9 @@ int VideoDevice::set_picture(PictureConfig *picture)
 
 		if(input_base) return input_base->set_picture(picture);
 	}
+
+
+  return 0;
 }
 
 int VideoDevice::update_translation()

--- a/cinelerra/zoombar.C
+++ b/cinelerra/zoombar.C
@@ -495,6 +495,8 @@ int AutoTypeMenu::from_text(char *text)
 		return AUTOGROUPTYPE_X;
 	if(!strcmp(text, to_text(AUTOGROUPTYPE_Y)))
 		return AUTOGROUPTYPE_Y;
+
+ return 0;
 }
 
 int AutoTypeMenu::handle_event()

--- a/cinelerra/zoompanel.C
+++ b/cinelerra/zoompanel.C
@@ -297,6 +297,8 @@ double ZoomPanel::text_to_zoom(char *text, int use_table)
 			break;
 		}
 	}
+
+  return 0.0;
 }
 
 

--- a/guicast/bcwindowbase.inc
+++ b/guicast/bcwindowbase.inc
@@ -24,7 +24,8 @@
 
 class BC_WindowBase;
 class BC_WindowList;
-#define BCTEXTLEN 1024
+//#define BCTEXTLEN 1024
+#define BCTEXTLEN 4096
 // Milliseconds before cursor disappears during video playback
 #define VIDEO_CURSOR_TIMEOUT 2000
 

--- a/plugins/blur/blur.C
+++ b/plugins/blur/blur.C
@@ -638,11 +638,11 @@ int BlurEngine::transfer_pixels(pixel_f *src1, pixel_f *src2, pixel_f *dest, int
 	return 0;
 }
 
-
+//FIXIT?
 int BlurEngine::multiply_alpha(pixel_f *row, int size)
 {
-	register int i;
-	register float alpha;
+	int i;
+	float alpha;
 
 // 	for(i = 0; i < size; i++)
 // 	{
@@ -656,9 +656,9 @@ int BlurEngine::multiply_alpha(pixel_f *row, int size)
 
 int BlurEngine::separate_alpha(pixel_f *row, int size)
 {
-	register int i;
-	register float alpha;
-	register float result;
+	int i;
+	float alpha;
+	float result;
 	
 // 	for(i = 0; i < size; i++)
 // 	{

--- a/plugins/denoise/denoise.C
+++ b/plugins/denoise/denoise.C
@@ -284,7 +284,7 @@ int DenoiseEffect::tree_copy(double **output,
 	int length, 
 	int levels)
 {
-	register int i, j, k, l, m;
+	int i, j, k, l, m;
 
 	for(i = 0, k = 1; k < levels; i++, k++)
 	{
@@ -378,7 +378,7 @@ int DenoiseEffect::convolve_int_2(double *input_sequence,
 // insert zeros between each element of the input sequence and
 // convolve with the filter to interpolate the data
 {
-	register int i, j;
+	int i, j;
 	int endpoint = length + filtlen - 2;
 
 	if (sum_output)

--- a/plugins/motion/motionwindow.C
+++ b/plugins/motion/motionwindow.C
@@ -876,6 +876,8 @@ int Mode1::from_text(char *text)
 	if(!strcmp(text, _("Stabilize Subpixel"))) return MotionConfig::STABILIZE;
 	if(!strcmp(text, _("Stabilize Pixel"))) return MotionConfig::STABILIZE_PIXEL;
 	if(!strcmp(text, _("Do Nothing"))) return MotionConfig::NOTHING;
+
+	return MotionConfig::NOTHING;
 }
 
 const char* Mode1::to_text(int mode)
@@ -947,6 +949,8 @@ int Mode2::from_text(char *text)
 	if(!strcmp(text, _("Recalculate"))) return MotionConfig::RECALCULATE;
 	if(!strcmp(text, _("Save coords to /tmp"))) return MotionConfig::SAVE;
 	if(!strcmp(text, _("Load coords from /tmp"))) return MotionConfig::LOAD;
+
+	return 0;
 }
 
 char* Mode2::to_text(int mode)
@@ -966,6 +970,8 @@ char* Mode2::to_text(int mode)
 			return _("Load coords from /tmp");
 			break;
 	}
+
+  return 0;
 }
 
 int Mode2::calculate_w(MotionWindow *gui)

--- a/plugins/perspective/perspective.C
+++ b/plugins/perspective/perspective.C
@@ -764,6 +764,9 @@ float PerspectiveMain::get_current_x()
 			return config.x4;
 			break;
 	}
+
+ return 0.0;
+
 }
 
 float PerspectiveMain::get_current_y()
@@ -783,6 +786,8 @@ float PerspectiveMain::get_current_y()
 			return config.y4;
 			break;
 	}
+
+   return 0.0;
 }
 
 void PerspectiveMain::set_current_x(float value)

--- a/plugins/svg/svgwin.C
+++ b/plugins/svg/svgwin.C
@@ -382,8 +382,8 @@ SvgInkscapeThread::~SvgInkscapeThread()
 void SvgInkscapeThread::run()
 {
 // Runs the inkscape
-	char command[1024];
-	char filename_raw[1024];
+	char command[4096]; //max Linux path
+	char filename_raw[4096];
 	strcpy(filename_raw, client->config.svg_file);
 	strcat(filename_raw, ".raw");
 

--- a/plugins/synthesizer/synthesizer.C
+++ b/plugins/synthesizer/synthesizer.C
@@ -245,7 +245,7 @@ double Synth::solve_eqn(double *output,
 	if(config->level <= INFINITYGAIN) return 0;
 
 	double result;
-	register double x;
+	double x;
 	double power = this->db.fromdb(config->level) * normalize_constant;
 	double phase_offset = config->phase * this->period;
 	double x3 = x1 + phase_offset;
@@ -340,6 +340,8 @@ double Synth::get_oscillator_point(float x,
 			return function_noise() * power;
 			break;
 	}
+
+   return 0.1;
 }
 
 double Synth::function_square(double x)

--- a/plugins/titler/title.C
+++ b/plugins/titler/title.C
@@ -1617,6 +1617,8 @@ char* TitleMain::motion_to_text(int motion)
 		case RIGHT_TO_LEFT: return _("Right to left"); break;
 		case LEFT_TO_RIGHT: return _("Left to right"); break;
 	}
+
+  return 0;
 }
 
 int TitleMain::text_to_motion(char *text)


### PR DESCRIPTION
The first portion of warning fixes that related to:
1. Functions without mandatory return operator.
2. Potential buffer overflow with strings (need to be rewritten anyway).